### PR TITLE
Get resource endpoint (api_resources_controller#show)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5304,3 +5304,6 @@ Rails/HasManyOrHasOneDependent:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/EmptyExampleGroup:
+  Enabled: false

--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -1,0 +1,15 @@
+class ApiApplicationController < ActionController::API
+  before_action :authenticate_user!
+
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found_error
+
+  private
+
+  def handle_record_not_found_error
+    code = 404
+    message = 'record_not_found'
+    status = :not_found
+
+    render json: { code:, message:, status: }, status:
+  end
+end

--- a/app/controllers/api_resources_controller.rb
+++ b/app/controllers/api_resources_controller.rb
@@ -1,0 +1,9 @@
+class ApiResourcesController < ApiApplicationController
+  def show
+    resource = Resource.find(params[:resource_id])
+    render json: {
+      'resource': resource.attributes.slice('id', 'name', 'url'),
+      'average_evaluation': resource.average_evaluation.to_f
+    }
+  end
+end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -18,4 +18,12 @@ class ResourcesController < ApplicationController
     )
     redirect_to(LearningUnit.find(learning_unit_id))
   end
+
+  def get_resource
+    resource = Resource.find(params[:resource_id])
+    render json: {
+      'resource': resource,
+      'average_evaluation': resource.average_evaluation.to_f
+    }
+  end
 end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -18,12 +18,4 @@ class ResourcesController < ApplicationController
     )
     redirect_to(LearningUnit.find(learning_unit_id))
   end
-
-  def get_resource
-    resource = Resource.find(params[:resource_id])
-    render json: {
-      'resource': resource,
-      'average_evaluation': resource.average_evaluation.to_f
-    }
-  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -17,4 +17,8 @@ class Resource < ApplicationRecord
   has_many :resource_evaluations
 
   validates :url, url: { allow_blank: true }
+
+  def average_evaluation
+    resource_evaluations.average(:evaluation)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   scope '/api' do
+    get '/resources/:resource_id', to: 'resources#get_resource'
   end
 
   resources :resources, only: %i[show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   devise_for :users
 
   scope '/api' do
-    get '/resources/:resource_id', to: 'resources#get_resource'
+    defaults format: :json do
+      get '/resources/:resource_id', to: 'api_resources#show'
+    end
   end
 
   resources :resources, only: %i[show] do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,9 +15,9 @@ CurriculumAffiliation.create(curriculum: first_curr,
 CurriculumAffiliation.create(curriculum: first_curr,
                              learning_unit: s_learning_unit)
 f_resource = Resource.create(user: f_user, learning_unit: f_learning_unit,
-                             name: 'Ruby for dummies', url: 'fakeurl.io')
+                             name: 'Ruby for dummies', url: 'http://www.fakeurl.io')
 s_resource = Resource.create(user: s_user, learning_unit: f_learning_unit,
-                             name: 'The best Ruby', url: 'fakeurl.io')
+                             name: 'The best Ruby', url: 'http://www.fakeurl.io')
 ResourceComment.create(user: s_user, resource: f_resource,
                        content: 'Vale pico tu wea')
 ResourceEvaluation.create(user: t_user, resource: f_resource, evaluation: 5)

--- a/spec/integration/api_resources_controller_spec.rb
+++ b/spec/integration/api_resources_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'swagger_helper'
+require 'rails_helper'
+
+describe ApiResourcesController do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  path '/api/resources/{resource_id}' do
+    get 'Retrieves a resource' do
+      tags 'Resources'
+      produces 'application/json'
+      parameter name: :resource_id, in: :path, type: :string
+
+      response '200', 'Success' do
+        schema type: :object, properties: {
+          'resource': {
+            type: :object, properties: {
+              'id': { type: :integer },
+              'name': { type: :string },
+              'url': { type: :string, nullable: true }
+            }
+          },
+          'average_evaluation': { type: :number, nullable: true }
+        }
+
+        let(:resource_id) { create(:resource).id }
+        run_test!
+      end
+
+      response '404', 'Resource Not Found' do
+        schema type: :object, properties: {
+          'code': { type: :integer },
+          'message': { type: :string },
+          'status': { type: :string }
+        }
+        let(:resource_id) { 'invalid' }
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -80,7 +80,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3000"
+      "url": "http://localhost:3001"
     }
   ]
 }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -5,6 +5,78 @@
     "version": "v1"
   },
   "paths": {
+    "/api/resources/{resource_id}": {
+      "get": {
+        "summary": "Retrieves a resource",
+        "tags": [
+          "Resources"
+        ],
+        "parameters": [
+          {
+            "name": "resource_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "average_evaluation": {
+                      "type": "number",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   },
   "servers": [
     {


### PR DESCRIPTION
The main goal of this PR was to create the endpoint to get a resource by its ID.

To do it, a few refactors and other features were needed, as described next:

- Disable rubocop's rule not compatible with rswag spec's standard.
- Default ApiApplicationController, for Api type controllers to inherit from.
- Method to handle record_not_found_errors in all Api Controllers (specified in ApiApplicationController).
- Method average_evaluation in Resource model, to retrieve it as an attribute of a resource.

Additionally, it's included in this PR the spec for the endpoint, and a modification to the seed file, which was outdated, because the url's of the resources created where not valid urls.