### PR TITLE
feat(listResources_endpoint): add controller and spec for listResources

### DIFF
--- a/app/controllers/api_resources_controller.rb
+++ b/app/controllers/api_resources_controller.rb
@@ -3,4 +3,10 @@ class ApiResourcesController < ApiApplicationController
     resource = Resource.find(params[:resource_id])
     render json: resource, only: %i[id name url], methods: [:average_evaluation]
   end
+
+  def resources_of_learning_unit
+    resources = LearningUnit.find(params[:learning_unit_id])&.resources
+    render json: resources, only: %i[id name url],
+           methods: [:average_evaluation]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
             'curriculums_learning_units_completed_by_user'
 
       get '/current_session', to: 'api_session#index'
+      
+      get '/learning_units/:learning_unit_id/resources',
+        to: 'api_resources#resources_of_learning_unit'
     end
   end
 

--- a/spec/integration/api_resources_controller_spec.rb
+++ b/spec/integration/api_resources_controller_spec.rb
@@ -38,4 +38,63 @@ describe ApiResourcesController do
       end
     end
   end
+
+  path '/api/learning_units/{learning_unit_id}/resources' do
+    get 'List of all resources belonging to a learning unit' do
+      tags 'Resources'
+      operationId 'listResources'
+      produces 'application/json'
+      parameter name: :learning_unit_id, in: :path, type: :string
+
+      response '200', 'Success' do
+        schema type: :array, items: {
+          properties: {
+            id: { type: :integer },
+            name: { type: :string },
+            url: { type: :string },
+            average_evaluation: { type: :string }
+          }
+        }
+        let(:learning_unit) { create(:learning_unit) }
+        let(:learning_unit_id) { learning_unit.id }
+        run_test!
+
+        context 'when there are no resources' do
+          before do |example|
+            submit_request(example.metadata)
+          end
+
+          it 'returns an empty array' do
+            data = JSON.parse(response.body)
+            expect(data.length).to eq(0)
+          end
+        end
+
+        context 'when there is one resource' do
+          before do |example|
+            create(
+              :resource,
+              learning_unit:
+            )
+            submit_request(example.metadata)
+          end
+
+          it 'returns an array with 1 element' do
+            data = JSON.parse(response.body)
+            expect(data.length).to eq(1)
+          end
+        end
+      end
+
+      response '404', 'Learning Unit Not Found' do
+        schema type: :object, properties: {
+          'code': { type: :integer },
+          'message': { type: :string },
+          'status': { type: :string }
+        }
+        let(:learning_unit_id) { 'invalid' }
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/integration/api_resources_controller_spec.rb
+++ b/spec/integration/api_resources_controller_spec.rb
@@ -55,8 +55,7 @@ describe ApiResourcesController do
             average_evaluation: { type: :string }
           }
         }
-        let(:learning_unit) { create(:learning_unit) }
-        let(:learning_unit_id) { learning_unit.id }
+        let(:learning_unit_id) { create(:learning_unit).id }
         run_test!
 
         context 'when there are no resources' do
@@ -74,7 +73,7 @@ describe ApiResourcesController do
           before do |example|
             create(
               :resource,
-              learning_unit:
+              learning_unit_id:
             )
             submit_request(example.metadata)
           end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -458,6 +458,74 @@
         }
       }
     },
+    "/api/learning_units/{learning_unit_id}/resources": {
+      "get": {
+        "summary": "List of all resources belonging to a learning unit",
+        "tags": [
+          "Resources"
+        ],
+        "operationId": "listResources",
+        "parameters": [
+          {
+            "name": "learning_unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      },
+                      "average_evaluation": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Learning Unit Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/current_session": {
       "get": {
         "summary": "Retrieves current user data",


### PR DESCRIPTION
Add method `resources_of_learning_unit` to `api_resource_controller` that returns an array of resources objects belonging to a learning unit. Also, modify routes and spec to test this endpoint.