### PR TITLE
feat: removed authorization to display curriculums in landing page

### DIFF
--- a/app/controllers/api_curriculums_controller.rb
+++ b/app/controllers/api_curriculums_controller.rb
@@ -1,4 +1,5 @@
 class ApiCurriculumsController < ApiApplicationController
+  skip_before_action :authenticate_user!, only: [:index]
   def index
     curriculums = Curriculum.all
     render json: curriculums, only: %i[id name]

--- a/spec/integration/api_curriculums_controller_spec.rb
+++ b/spec/integration/api_curriculums_controller_spec.rb
@@ -4,10 +4,6 @@ require 'rails_helper'
 describe ApiCurriculumsController do
   let(:user) { create(:user) }
 
-  before do
-    sign_in user
-  end
-
   path '/api/curriculums' do
     get 'List of all curriculums' do
       tags 'Curriculums'
@@ -60,6 +56,10 @@ describe ApiCurriculumsController do
         end
       end
     end
+  end
+
+  before do
+    sign_in user
   end
 
   path '/api/curriculums/{curriculum_id}' do


### PR DESCRIPTION
Just skipped the authentication for curriculums index endpoint